### PR TITLE
Add UINavigationControllerDelegate methods needed for custom transitions to work

### DIFF
--- a/Classes/AHKNavigationController.m
+++ b/Classes/AHKNavigationController.m
@@ -64,6 +64,22 @@
     }
 }
 
+- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController animationControllerForOperation:(UINavigationControllerOperation)operation fromViewController:(UIViewController*)fromVC toViewController:(UIViewController*)toVC
+{
+    if ([self.realDelegate respondsToSelector:_cmd]) {
+        return [self.realDelegate navigationController:navigationController animationControllerForOperation:operation fromViewController:fromVC toViewController:toVC];
+    }
+    return nil;
+}
+
+- (id <UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController*)navigationController interactionControllerForAnimationController:(id <UIViewControllerAnimatedTransitioning>)animationController
+{
+    if ([self.realDelegate respondsToSelector:_cmd]) {
+        return [self.realDelegate navigationController:navigationController interactionControllerForAnimationController:animationController];
+    }
+    return nil;
+}
+
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
Without these delegate methods AHKNavigationController doesn't allow custom transitions to be implemented. The delegate forwarding doesn't seem to work because the system calls respondsToSelector: when the realDelegate is not yet set and caches that responses so later, when a view controller sets the custom delegate the system doesn't call again respondsToSelector: and the call is not forwarded.