### PR TITLE
Make sure message forwarding works

### DIFF
--- a/Classes/AHKNavigationController.m
+++ b/Classes/AHKNavigationController.m
@@ -38,8 +38,8 @@
 
 - (void)setDelegate:(id<UINavigationControllerDelegate>)delegate
 {
+	self.realDelegate = delegate != self ? delegate : nil;
     [super setDelegate:delegate ? self : nil];
-    self.realDelegate = delegate != self ? delegate : nil;
 }
 
 - (void)pushViewController:(UIViewController *)viewController

--- a/Classes/AHKNavigationController.m
+++ b/Classes/AHKNavigationController.m
@@ -64,22 +64,6 @@
     }
 }
 
-- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController animationControllerForOperation:(UINavigationControllerOperation)operation fromViewController:(UIViewController*)fromVC toViewController:(UIViewController*)toVC
-{
-    if ([self.realDelegate respondsToSelector:_cmd]) {
-        return [self.realDelegate navigationController:navigationController animationControllerForOperation:operation fromViewController:fromVC toViewController:toVC];
-    }
-    return nil;
-}
-
-- (id <UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController*)navigationController interactionControllerForAnimationController:(id <UIViewControllerAnimatedTransitioning>)animationController
-{
-    if ([self.realDelegate respondsToSelector:_cmd]) {
-        return [self.realDelegate navigationController:navigationController interactionControllerForAnimationController:animationController];
-    }
-    return nil;
-}
-
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
This is a more generic fix for the problem which was fixed by PR #2 
With some delegate methods, such as methods needed for custom transitions, system calls respondsToSelector: as early as in setDelegate:, and caches that response. With nil realDelegate this would mean the delegate method never gets called. So this fix makes sure at that point there's a correct realDelegate already.